### PR TITLE
Relax langchain-community version constraint

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,7 +1,7 @@
 fastapi>=0.100.0
 git+https://github.com/langchain-ai/langserve.git@main
 langchain>=0.1.0,<0.2.0
-langchain-community>=0.1.0,<0.2.0
+langchain-community>=0.0.30,<0.3.0
 openai>=0.27.0
 python-dotenv>=1.0.0
 uvicorn[standard]>=0.22.0


### PR DESCRIPTION
## Summary
- relax the langchain-community version range in `requirements.txt`

## Testing
- `python -m py_compile $(git ls-files '*.py')`

------
https://chatgpt.com/codex/tasks/task_b_6856535a6cb8832ca6e9318789374782