### PR TITLE
Fix Pydantic version handling

### DIFF
--- a/main.py
+++ b/main.py
@@ -4,8 +4,8 @@ from fastapi import FastAPI
 from fastapi.middleware.cors import CORSMiddleware
 from dotenv import load_dotenv
 from langserve import add_routes
-# from langserve.validation import ChatbotBatchRequest
-# from pydantic import __version__ as pydantic_version
+from langserve.validation import ChatbotBatchRequest
+from pydantic import __version__ as pydantic_version
 
 from agent import build_agent
 
@@ -16,6 +16,12 @@ def create_app() -> FastAPI:
     env = os.getenv("ENV", "local")
     logging.basicConfig(level=logging.INFO)
     logging.info(f"🟢 Starting Eyewear Chatbot API in '{env}' environment")
+
+    major_version = int(pydantic_version.split(".")[0])
+    if major_version >= 2:
+        ChatbotBatchRequest.model_rebuild()
+    else:
+        ChatbotBatchRequest.update_forward_refs()
 
 
     app = FastAPI(


### PR DESCRIPTION
## Summary
- enable `ChatbotBatchRequest` & `pydantic.__version__` imports
- rebuild/update ChatbotBatchRequest model depending on Pydantic major version

## Testing
- `python -m py_compile $(git ls-files '*.py')`
- `env OPENAI_API_KEY=sk-test uvicorn main:app --port 8000 --host 127.0.0.1 --log-level error` *(fails: uvicorn not installed)*

------
https://chatgpt.com/codex/tasks/task_b_685657b7933c832c8a9836ac6c2302f4