### PR TITLE
Add env example template

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,0 +1,15 @@
+# Example environment variables for Chatbot Engine
+
+# Environment the app is running in (local, development, production)
+ENV=local
+
+# Port for the FastAPI server
+PORT=8000
+
+# API key for OpenAI services
+OPENAI_API_KEY=your-openai-api-key
+
+# SQL database connection URIs
+SQL_DATABASE_URI_LIVE=mysql+pymysql://user:password@localhost:3306/live_db
+SQL_DATABASE_URI_COMMON=mysql+pymysql://user:password@localhost:3306/common_db
+

--- a/.gitignore
+++ b/.gitignore
@@ -29,6 +29,7 @@ build/
 # dotenv environment files
 .env
 .env.*
+!.env.example
 
 # SQLAlchemy or Alembic cache/migrations (if any)
 *.db

--- a/README.md
+++ b/README.md
@@ -8,7 +8,9 @@ This project provides a lightweight FastAPI service powered by LangChain and Lan
    ```bash
    pip install -r requirements.txt
    ```
-2. Copy `.env.example` to `.env` and fill in your configuration values.
+2. Copy `.env.example` to `.env` and fill in your configuration values. The
+   template includes placeholders for variables like `OPENAI_API_KEY`,
+   `SQL_DATABASE_URI_LIVE` and `SQL_DATABASE_URI_COMMON`.
 3. Start the server:
    ```bash
    uvicorn main:app --reload


### PR DESCRIPTION
## Summary
- provide `.env.example` with placeholders for DB and API settings
- ensure `.gitignore` tracks the example env file
- document required variables in the README

## Testing
- `python -m pytest -q`

------
https://chatgpt.com/codex/tasks/task_b_6856d3fa062c832cb95fa72a52f6d542