### PR TITLE
Configure test DB URI via environment

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,0 +1,13 @@
+# Example environment configuration
+# Copy this file to `.env` and replace values with your own.
+
+# Database URIs for the SQL tools
+SQL_DATABASE_URI_LIVE=mysql+pymysql://user:pass@host:3306/eyewa_live
+SQL_DATABASE_URI_COMMON=mysql+pymysql://user:pass@host:3306/eyewa_common
+
+# URI for the connection test in test.py
+TEST_DB_URI=mysql+pymysql://user:pass@host:3306/your_db
+
+# Optional application settings
+ENV=local
+PORT=8000

--- a/README.md
+++ b/README.md
@@ -9,8 +9,10 @@ This project provides a lightweight FastAPI service powered by LangChain and Lan
    pip install -r requirements.txt
    ```
 2. Copy `.env.example` to `.env` and fill in your configuration values.
-3. Start the server:
+3. Set the `TEST_DB_URI` environment variable if you want to run `test.py` for
+   a database connectivity check.
+4. Start the server:
    ```bash
    uvicorn main:app --reload
    ```
-4. Open `http://localhost:8000/docs` for interactive API docs.
+5. Open `http://localhost:8000/docs` for interactive API docs.

--- a/test.py
+++ b/test.py
@@ -1,7 +1,8 @@
 from sqlalchemy import create_engine, text
+import os
 
-# Replace with your actual DB URI
-db_uri = "mysql+pymysql://read_only:Aukdfduyje983idbj@db.eyewa.internal:3306/eyewa_live"
+# DB URI is now read from the TEST_DB_URI environment variable
+db_uri = os.getenv("TEST_DB_URI")
 
 try:
     engine = create_engine(db_uri)


### PR DESCRIPTION
## Summary
- set `TEST_DB_URI` in `test.py` instead of hard-coded URI
- document `TEST_DB_URI` usage in README
- add `.env.example` with placeholders including `TEST_DB_URI`

## Testing
- `python -m py_compile $(git ls-files '*.py')`

------
https://chatgpt.com/codex/tasks/task_b_6856d3f913b4832c95b3cde4ae06d6b7