### PR TITLE
Ensure unique names for SQL tools

### DIFF
--- a/agent.py
+++ b/agent.py
@@ -8,13 +8,18 @@ from tools.sql_tool import get_live_sql_tools, get_common_sql_tools
 def build_chatbot_agent():
 
     """
-    Constructs and returns a LangChain AgentExecutor for Winkly, the Eyewa assistant.
-    The agent uses tools from the eyewa_live and eyewa_common SQL databases and
-    responds based on a custom ChatPromptTemplate including chat history and scratchpad.
+    Construct and return the chatbot agent.
+
+    SQL tools are loaded from both the ``eyewa_live`` and ``eyewa_common``
+    databases. Each tool is automatically suffixed with the database label
+    (e.g. ``sql_db_query_live``) to avoid name collisions when registered with
+    the agent.
     """
     
     llm = ChatOpenAI(model="gpt-3.5-turbo", temperature=0)
 
+    # SQL tools already have unique names like ``sql_db_query_live`` to prevent
+    # collisions across databases.
     tools = get_live_sql_tools() + get_common_sql_tools()
 
     prompt = ChatPromptTemplate.from_messages([

--- a/tools/sql_tool.py
+++ b/tools/sql_tool.py
@@ -7,6 +7,13 @@ from langchain_community.agent_toolkits.sql.toolkit import SQLDatabaseToolkit
 from langchain_openai import ChatOpenAI
 from functools import lru_cache
 
+
+def _rename_tools(tools, suffix: str):
+    """Return tools with their names suffixed by the given database label."""
+    for tool in tools:
+        tool.name = f"{tool.name}_{suffix}"
+    return tools
+
 load_dotenv()
 
 llm = ChatOpenAI(model="gpt-3.5-turbo", temperature=0)
@@ -17,7 +24,8 @@ def get_live_sql_tools():
     db_live = SQLDatabase.from_uri(db_uri, include_tables=["sales_order"], sample_rows_in_table_info=5)
     print("✅ Live DB tables:", db_live.get_usable_table_names()) 
     toolkit = SQLDatabaseToolkit(db=db_live, llm=llm)
-    return toolkit.get_tools()
+    tools = toolkit.get_tools()
+    return _rename_tools(tools, "live")
 
 @lru_cache
 def get_common_sql_tools():
@@ -25,4 +33,5 @@ def get_common_sql_tools():
     db_common = SQLDatabase.from_uri(db_uri, include_tables=["customer_loyalty_card"], sample_rows_in_table_info=5)
     print("✅ common DB tables:", db_common.get_usable_table_names()) 
     toolkit = SQLDatabaseToolkit(db=db_common, llm=llm)
-    return toolkit.get_tools()
+    tools = toolkit.get_tools()
+    return _rename_tools(tools, "common")


### PR DESCRIPTION
## Summary
- add helper to suffix SQL tool names with database identifiers
- note unique SQL tool names when building the agent

## Testing
- `python -m py_compile $(git ls-files '*.py')`

------
https://chatgpt.com/codex/tasks/task_b_6856d3f7a150832caa548532c192fa7d