### PR TITLE
Add customer ID regex and negative test

### DIFF
--- a/agent_router.py
+++ b/agent_router.py
@@ -8,7 +8,8 @@ appropriate agent using an LLM-based intent classifier.
 """
 
 import logging
-from typing import Dict, Any
+import re
+from typing import Dict, Any, Optional
 
 from langchain.agents import create_openai_functions_agent, AgentExecutor
 from langchain_core.prompts import ChatPromptTemplate, MessagesPlaceholder
@@ -21,6 +22,15 @@ from langchain_core.runnables import (
 from langchain_openai import ChatOpenAI
 
 from tools.sql_tool import get_live_sql_tools, get_common_sql_tools
+
+
+def _extract_customer_id(query: str) -> Optional[str]:
+    """Return the customer ID from a query if explicitly mentioned."""
+    pattern = re.compile(r"(?i)customer(?:\s*id)?\s*[:#-]?\s*(\d+)")
+    match = pattern.search(query or "")
+    if match:
+        return match.group(1)
+    return None
 
 
 def _build_agent(tools, system_message: str) -> AgentExecutor:

--- a/tests/test_agent_router.py
+++ b/tests/test_agent_router.py
@@ -1,0 +1,55 @@
+import importlib.util
+import sys
+import types
+from pathlib import Path
+
+
+def _load_module():
+    packages = {
+        "langchain": {},
+        "langchain.agents": {
+            "create_openai_functions_agent": lambda *a, **k: None,
+            "AgentExecutor": object,
+        },
+        "langchain_core.prompts": {
+            "ChatPromptTemplate": object,
+            "MessagesPlaceholder": object,
+        },
+        "langchain_core.output_parsers": {"StrOutputParser": object},
+        "langchain_core.runnables": {
+            "RunnablePassthrough": object,
+            "RunnableLambda": object,
+            "RunnableBranch": object,
+        },
+        "langchain_openai": {"ChatOpenAI": object},
+    }
+
+    for name, attrs in packages.items():
+        mod = sys.modules.get(name)
+        if mod is None:
+            mod = types.ModuleType(name)
+            sys.modules[name] = mod
+        for attr, val in attrs.items():
+            setattr(mod, attr, val)
+
+    if "tools" not in sys.modules:
+        sys.modules["tools"] = types.ModuleType("tools")
+    sql_tool = types.ModuleType("tools.sql_tool")
+    sql_tool.get_live_sql_tools = lambda: None
+    sql_tool.get_common_sql_tools = lambda: None
+    sys.modules["tools.sql_tool"] = sql_tool
+
+    spec = importlib.util.spec_from_file_location(
+        "agent_router", Path(__file__).resolve().parents[1] / "agent_router.py"
+    )
+    module = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(module)
+    return module
+
+
+agent_router = _load_module()
+
+
+def test_extract_customer_id_negative():
+    query = "What is the status of order 78910?"
+    assert agent_router._extract_customer_id(query) is None


### PR DESCRIPTION
## Summary
- parse customer IDs only when preceded by "customer" or "customer id"
- create a unit test verifying no ID is found when an order number is given

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_b_685704ceef9c832c8b629d3440b98d30