### PR TITLE
Add live write DB URI and chat history repo

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -12,4 +12,5 @@ OPENAI_API_KEY=your-openai-api-key
 # SQL database connection URIs
 SQL_DATABASE_URI_LIVE=mysql+pymysql://user:password@localhost:3306/live_db
 SQL_DATABASE_URI_COMMON=mysql+pymysql://user:password@localhost:3306/common_db
+SQL_DATABASE_URI_LIVE_WRITE=mysql+pymysql://user:password@localhost:3306/live_write_db
 

--- a/README.md
+++ b/README.md
@@ -10,7 +10,8 @@ This project provides a lightweight FastAPI service powered by LangChain and Lan
    ```
 2. Copy `.env.example` to `.env` and fill in your configuration values. The
    template includes placeholders for variables like `OPENAI_API_KEY`,
-   `SQL_DATABASE_URI_LIVE` and `SQL_DATABASE_URI_COMMON`.
+   `SQL_DATABASE_URI_LIVE`, `SQL_DATABASE_URI_COMMON` and
+   `SQL_DATABASE_URI_LIVE_WRITE`.
 3. Start the server:
    ```bash
    uvicorn main:app --reload

--- a/chat_history_repository.py
+++ b/chat_history_repository.py
@@ -1,0 +1,19 @@
+import os
+from dotenv import load_dotenv
+from sqlalchemy import create_engine
+
+class ChatHistoryRepository:
+    """Simple repository for persisting chat history."""
+
+    def __init__(self):
+        load_dotenv()
+        uri = os.getenv("SQL_DATABASE_URI_LIVE_WRITE")
+        if not uri:
+            raise RuntimeError("SQL_DATABASE_URI_LIVE_WRITE is not set")
+        self.engine = create_engine(uri)
+
+    def save_message(self, message: str):
+        # Placeholder implementation
+        with self.engine.begin() as conn:
+            conn.execute("INSERT INTO chat_history (message) VALUES (:message)", {"message": message})
+

--- a/tests/test_chat_history_repository.py
+++ b/tests/test_chat_history_repository.py
@@ -1,0 +1,19 @@
+import os
+import pytest
+from unittest import mock
+
+import chat_history_repository as chr
+
+
+def test_init_raises_when_env_missing(monkeypatch):
+    monkeypatch.delenv("SQL_DATABASE_URI_LIVE_WRITE", raising=False)
+    with pytest.raises(RuntimeError):
+        chr.ChatHistoryRepository()
+
+
+def test_init_uses_env(monkeypatch):
+    monkeypatch.setenv("SQL_DATABASE_URI_LIVE_WRITE", "sqlite:///:memory:")
+    with mock.patch("chat_history_repository.create_engine") as ce:
+        repo = chr.ChatHistoryRepository()
+        ce.assert_called_with("sqlite:///:memory:")
+


### PR DESCRIPTION
## Summary
- add `SQL_DATABASE_URI_LIVE_WRITE` example
- document new URI in README
- add `ChatHistoryRepository` that reads from `SQL_DATABASE_URI_LIVE_WRITE`
- test repository initialization

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'dotenv' and 'langchain')*

------
https://chatgpt.com/codex/tasks/task_b_68579480e778832c9a5aeab1e8fcab08