### PR TITLE
Fix loyalty schema prompt and add YAML fallback

### DIFF
--- a/agent/schema_validator.py
+++ b/agent/schema_validator.py
@@ -1,6 +1,9 @@
 # schema_utils.py
 
-import yaml
+try:
+    import yaml  # type: ignore
+except Exception:  # PyYAML may be unavailable
+    yaml = None
 import json
 from pathlib import Path
 from typing import Dict, Any, Optional
@@ -11,8 +14,13 @@ def validate_schema_yaml(path: str) -> Dict[str, Any]:
     if not schema_path.exists():
         raise FileNotFoundError(f"❌ Schema file not found: {path}")
 
-    with schema_path.open("r", encoding="utf-8") as f:
-        data = yaml.safe_load(f)
+    if yaml is not None:
+        with schema_path.open("r", encoding="utf-8") as f:
+            data = yaml.safe_load(f)
+    else:
+        json_path = schema_path.with_suffix(".json")
+        with json_path.open("r", encoding="utf-8") as jf:
+            data = json.load(jf)
 
     assert isinstance(data, dict), "❌ Top-level YAML structure must be a dictionary"
     assert "tables" in data, "❌ Missing 'tables' key in schema"

--- a/config/schema/schema.json
+++ b/config/schema/schema.json
@@ -1,0 +1,49 @@
+{
+  "schema_version": 1.0,
+  "tables": {
+    "sales_order": {
+      "description": "Orders placed by customers. `increment_id` is usually referred to as the order number externally.",
+      "fields": ["entity_id", "increment_id", "customer_id", "grand_total", "status", "created_at"],
+      "joins": [
+        {"to_table": "customer_entity", "from_field": "customer_id", "to_field": "entity_id"},
+        {"to_table": "sales_order_payment", "from_field": "entity_id", "to_field": "parent_id"}
+      ]
+    },
+    "sales_order_payment": {
+      "description": "Payment records for each order.",
+      "fields": ["parent_id", "amount_paid", "method"],
+      "joins": [
+        {"to_table": "sales_order", "from_field": "parent_id", "to_field": "entity_id"}
+      ]
+    },
+    "customer_entity": {
+      "description": "Customer profile information.",
+      "fields": ["entity_id", "first_name", "last_name", "email", "created_at"],
+      "joins": [
+        {"to_table": "customer_loyalty_card", "from_field": "entity_id", "to_field": "customer_id"}
+      ]
+    },
+    "customer_loyalty_card": {
+      "description": "Loyalty program cards linked to customers. The table only contains `card_id`, `card_number` and `customer_id` fields and has **no** wallet information.",
+      "fields": ["card_id", "card_number", "customer_id"],
+      "joins": [
+        {"to_table": "customer_entity", "from_field": "customer_id", "to_field": "entity_id"}
+      ]
+    },
+    "customer_loyalty_ledger": {
+      "description": "Loyalty point transactions for each wallet or card. It records points in `point_delta` with an optional `reason` and timestamp but does not store any order or payment amounts.",
+      "fields": ["entry_id", "card_id", "point_delta", "reason", "created_at", "wallet_id"],
+      "joins": [
+        {"to_table": "customer_wallet", "from_field": "wallet_id", "to_field": "entity_id"},
+        {"to_table": "customer_loyalty_card", "from_field": "card_id", "to_field": "card_id"}
+      ]
+    },
+    "customer_wallet": {
+      "description": "Wallets linked to customer accounts.",
+      "fields": ["entity_id", "customer_id"],
+      "joins": [
+        {"to_table": "customer_entity", "from_field": "customer_id", "to_field": "entity_id"}
+      ]
+    }
+  }
+}

--- a/config/schema/schema.yaml
+++ b/config/schema/schema.yaml
@@ -32,7 +32,10 @@ tables:
         to_field: customer_id
 
   customer_loyalty_card:
-    description: Loyalty program cards linked to customers.
+    description: >
+      Loyalty program cards linked to customers. The table only contains
+      `card_id`, `card_number` and `customer_id` fields and has **no**
+      wallet information.
     fields: [card_id, card_number, customer_id]
     joins:
       - to_table: customer_entity
@@ -40,7 +43,10 @@ tables:
         to_field: entity_id
 
   customer_loyalty_ledger:
-    description: Loyalty point transactions for each wallet or card.
+    description: >
+      Loyalty point transactions for each wallet or card. It records
+      points in `point_delta` with an optional `reason` and timestamp but
+      does not store any order or payment amounts.
     fields: [entry_id, card_id, point_delta, reason, created_at, wallet_id]
     joins:
       - to_table: customer_wallet

--- a/tools/sql_tool.py
+++ b/tools/sql_tool.py
@@ -5,7 +5,10 @@ from functools import lru_cache
 from pathlib import Path
 from typing import Any, Dict, List, Optional
 
-import yaml
+try:
+    import yaml  # type: ignore
+except Exception:
+    yaml = None
 
 try:
     from dotenv import load_dotenv
@@ -51,8 +54,12 @@ class PromptBuilder:
             logging.warning(f"⚠️ YAML file not found: {path}")
             return {}
         try:
-            with path.open("r", encoding="utf-8") as f:
-                return yaml.safe_load(f) or {}
+            if yaml is not None:
+                with path.open("r", encoding="utf-8") as f:
+                    return yaml.safe_load(f) or {}
+            json_path = path.with_suffix(".json")
+            with json_path.open("r", encoding="utf-8") as f:
+                return json.load(f)
         except Exception as e:
             logging.error(f"❌ Failed to load YAML: {path} — {e}")
             return {}


### PR DESCRIPTION
## Summary
- clarify loyalty tables in `schema.yaml`
- provide pre-parsed `schema.json` for environments lacking PyYAML
- load schema configs from JSON when PyYAML isn't installed

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_b_6857c3ba27b8832c983fc14fed1ea5af