### PR TITLE
Fix prompt schema and field filtering

### DIFF
--- a/agent/prompt_builder.py
+++ b/agent/prompt_builder.py
@@ -93,7 +93,7 @@ class PromptBuilder:
         )
         lines.append("⚠️ You must not hallucinate or guess column names.")
         lines.append(
-            "🛑 Do NOT use fields like 'loyalty_card' in eyewa_live — that belongs to eyewa_common."
+            "🛑 Do NOT use fields like 'loyalty_card', 'first_name', or 'point_delta' that are not listed above."
         )
 
         if db == "eyewa_common":

--- a/config/schema/schema.json
+++ b/config/schema/schema.json
@@ -3,7 +3,7 @@
   "tables": {
     "sales_order": {
       "description": "Orders placed by customers. `increment_id` is usually referred to as the order number externally.",
-      "fields": ["entity_id", "increment_id", "customer_id", "grand_total", "status", "created_at"],
+      "fields": ["entity_id", "increment_id", "grand_total", "created_at"],
       "joins": [
         {"to_table": "customer_entity", "from_field": "customer_id", "to_field": "entity_id"},
         {"to_table": "sales_order_payment", "from_field": "entity_id", "to_field": "parent_id"}
@@ -18,7 +18,7 @@
     },
     "customer_entity": {
       "description": "Customer profile information.",
-      "fields": ["entity_id", "first_name", "last_name", "email", "created_at"],
+      "fields": ["entity_id", "firstname", "lastname", "email"],
       "joins": [
         {"to_table": "customer_loyalty_card", "from_field": "entity_id", "to_field": "customer_id"}
       ]
@@ -31,8 +31,8 @@
       ]
     },
     "customer_loyalty_ledger": {
-      "description": "Loyalty point transactions for each wallet or card. It records points in `point_delta` with an optional `reason` and timestamp but does not store any order or payment amounts.",
-      "fields": ["entry_id", "card_id", "point_delta", "reason", "created_at", "wallet_id"],
+      "description": "Loyalty point transactions for each wallet or card. It records points in `points_delta` with an optional `reason` and timestamp but does not store any order or payment amounts.",
+      "fields": ["entry_id", "card_id", "points_delta", "reason", "created_at", "wallet_id"],
       "joins": [
         {"to_table": "customer_wallet", "from_field": "wallet_id", "to_field": "entity_id"},
         {"to_table": "customer_loyalty_card", "from_field": "card_id", "to_field": "card_id"}

--- a/config/schema/schema.yaml
+++ b/config/schema/schema.yaml
@@ -6,7 +6,7 @@ schema_version: 1.0
 tables:
   sales_order:
     description: Orders placed by customers. `increment_id` is usually referred to as the order number externally.
-    fields: [entity_id, increment_id, customer_id, grand_total, status, created_at]
+    fields: [entity_id, increment_id, grand_total, created_at]
     joins:
       - to_table: customer_entity
         from_field: customer_id
@@ -25,7 +25,7 @@ tables:
 
   customer_entity:
     description: Customer profile information.
-    fields: [entity_id, first_name, last_name, email, created_at]
+    fields: [entity_id, firstname, lastname, email]
     joins:
       - to_table: customer_loyalty_card  # 💡 Cross DB, conceptually allowed for lookup
         from_field: entity_id
@@ -45,9 +45,9 @@ tables:
   customer_loyalty_ledger:
     description: >
       Loyalty point transactions for each wallet or card. It records
-      points in `point_delta` with an optional `reason` and timestamp but
+      points in `points_delta` with an optional `reason` and timestamp but
       does not store any order or payment amounts.
-    fields: [entry_id, card_id, point_delta, reason, created_at, wallet_id]
+    fields: [entry_id, card_id, points_delta, reason, created_at, wallet_id]
     joins:
       - to_table: customer_wallet
         from_field: wallet_id


### PR DESCRIPTION
## Summary
- restrict schema field lists to real columns
- warn against hallucinated field names
- filter merged response fields using helper

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_b_6857d23386a4832c8b83daa946c84134