### PR TITLE
Fix hallucinations and add query validation

### DIFF
--- a/tests/test_router.py
+++ b/tests/test_router.py
@@ -111,8 +111,8 @@ def test_combine_responses_filters_and_merges():
     result = json.loads(out)
 
     assert result["type"] == "mixed_summary"
-    assert result["data"]["live_data"] == {"grand_total": 100}
-    assert result["data"]["common_data"] == {"card_number": "777"}
+    assert result["data"]["orders"] == {"grand_total": 100}
+    assert result["data"]["loyalty_card"] == {"card_number": "777"}
 
 
 def test_combine_responses_single_agent():
@@ -122,7 +122,7 @@ def test_combine_responses_single_agent():
     result = json.loads(out)
 
     assert result["type"] == "mixed_summary"
-    assert result["data"] == {"live_data": {"grand_total": 50}}
+    assert result["data"] == {"orders": {"grand_total": 50}, "loyalty_card": None}
 
 
 def test_combine_responses_no_data():

--- a/tests/test_sql_validation.py
+++ b/tests/test_sql_validation.py
@@ -1,0 +1,11 @@
+import pytest
+from tools.sql_tool import _validate_query
+
+def test_validate_query_rejects_invalid_column():
+    schema = {"customer_entity": ["entity_id", "email"]}
+    with pytest.raises(ValueError):
+        _validate_query("SELECT ce.loyalty_card FROM customer_entity as ce", schema)
+
+def test_validate_query_allows_valid_columns():
+    schema = {"customer_entity": ["entity_id", "email"]}
+    assert _validate_query("SELECT ce.email FROM customer_entity ce", schema) is None


### PR DESCRIPTION
## Summary
- enforce schema-based column checks for SQL tools
- support partial data merging for live/common outputs
- add SQL validation tests
- adjust router tests for new mixed_summary format

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_b_68580a05fd54832c8713a65fdbecb376