### PR TITLE
Improve SQL table extraction

### DIFF
--- a/config/schema/schema.yaml
+++ b/config/schema/schema.yaml
@@ -20,6 +20,7 @@ tables:
 
   sales_order:
     description: Orders placed by customers.
+    customInfo: "links: customer_entity, payments"
     fields: [entity_id, increment_id, customer_id, customer_firstname, customer_lastname, customer_email, grand_total, created_at]
     joins:
       - to_table: customer_entity
@@ -86,6 +87,7 @@ tables:
 
   customer_wallet:
     description: Wallets linked to customer accounts.
+    customInfo: "customer_id joins to customer_entity"
     fields: [entity_id, customer_id, store_code, status, customer_balance, cashback_balance, created_at, updated_at, loyalty_balance, next_loyalty_expiry, credits_balance]
     joins:
       - to_table: customer_entity

--- a/tests/test_extract_table_names.py
+++ b/tests/test_extract_table_names.py
@@ -1,0 +1,16 @@
+import pytest
+from tools.sql_tool import extract_table_names
+
+
+def test_extract_table_names_simple():
+    sql = "SELECT * FROM sales_order"
+    assert extract_table_names(sql) == ["sales_order"]
+
+
+def test_extract_table_names_with_join():
+    sql = (
+        "SELECT so.increment_id FROM sales_order so "
+        "JOIN customer_entity ce ON so.customer_id = ce.entity_id"
+    )
+    names = extract_table_names(sql)
+    assert set(names) == {"sales_order", "customer_entity"}


### PR DESCRIPTION
## Summary
- parse table names from SQL queries using regex
- guard schema calls with new extraction logic
- update schema with customInfo metadata
- add tests for table name extraction

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_b_685819d464d0832c9f350eb3e91aac9a