### PR TITLE
Improve SQL validation and fallback query

### DIFF
--- a/agent/agent_router.py
+++ b/agent/agent_router.py
@@ -237,9 +237,11 @@ def _handle_both(input_dict):
     while attempts < 2 and common_resp is None:
         try:
             if attempts == 1 and cid and not fallback_applied:
-                sub_inputs["common"][
-                    "input"
-                ] = f"SELECT card_number FROM customer_loyalty_card WHERE customer_id = {cid};"
+                sub_inputs["common"]["input"] = (
+                    "SELECT clc.card_number FROM customer_loyalty_card clc "
+                    "JOIN customer_loyalty_ledger cll ON clc.wallet_id = cll.wallet_id "
+                    f"WHERE clc.customer_id = {cid};"
+                )
                 fallback_applied = True
             common_resp = common_agent.invoke(sub_inputs["common"])
         except Exception as exc:

--- a/tests/test_sql_validation.py
+++ b/tests/test_sql_validation.py
@@ -9,3 +9,21 @@ def test_validate_query_rejects_invalid_column():
 def test_validate_query_allows_valid_columns():
     schema = {"customer_entity": ["entity_id", "email"]}
     assert _validate_query("SELECT ce.email FROM customer_entity ce", schema) is None
+
+
+def test_validate_query_resolves_aliases():
+    schema = {
+        "sales_order": ["entity_id", "customer_id"],
+        "customer_entity": ["entity_id"],
+    }
+    q = (
+        "SELECT so.entity_id FROM sales_order so "
+        "JOIN customer_entity ce ON so.customer_id = ce.entity_id"
+    )
+    assert _validate_query(q, schema) is None
+
+
+def test_validate_query_ignores_select_aliases():
+    schema = {"sales_order": ["entity_id"]}
+    q = "SELECT so.entity_id AS order_id FROM sales_order so"
+    assert _validate_query(q, schema) is None

--- a/tools/sql_tool.py
+++ b/tools/sql_tool.py
@@ -174,14 +174,14 @@ def _validate_query(query: str | dict, schema_map: Dict[str, List[str]]) -> None
     if isinstance(query, dict):
         query = query.get("query", "")
     alias_map = {}
-    for kw in ["from", "join"]:
-        for tbl, alias in re.findall(
-            fr"{kw}\s+([a-zA-Z_][\w]*)\s+(?:as\s+)?([a-zA-Z_][\w]*)",
-            query,
-            flags=re.I,
-        ):
-
+    for tbl, alias in re.findall(
+        r"(?i)\b(?:from|join)\s+([a-zA-Z_][\w]*)\s*(?:as\s+)?([a-zA-Z_][\w]*)?",
+        query,
+    ):
+        if alias:
             alias_map[alias] = tbl
+        else:
+            alias_map[tbl] = tbl
 
     pairs = re.findall(r"([a-zA-Z_][\w]*)\.([a-zA-Z_][\w]*)", query)
     for table, column in pairs:


### PR DESCRIPTION
## Summary
- handle table aliases more robustly in SQL validation
- join loyalty tables with distinct aliases during fallback
- add regression tests for alias handling

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_b_6858204d66f0832cb05cf4c74dfeb218